### PR TITLE
feat(Trello): replace command to get random cards to get all cards

### DIFF
--- a/lib/lita-trello-democracy.rb
+++ b/lib/lita-trello-democracy.rb
@@ -8,7 +8,7 @@ Lita.load_locales Dir[File.expand_path(
 )]
 
 require "lita/commands/trello/base"
-require "lita/commands/trello/get_random_cards"
+require "lita/commands/trello/get_cards"
 require "lita/handlers/vote_handler"
 
 Lita::Handlers::VoteHandler.template_root File.expand_path(

--- a/lib/lita/commands/trello/get_cards.rb
+++ b/lib/lita/commands/trello/get_cards.rb
@@ -1,7 +1,7 @@
 module Lita
   module Commands
     module Trello
-      class GetRandomCards < Base
+      class GetCards < Base
         def perform
           inbox_cards
         end
@@ -19,7 +19,7 @@ module Lita
         end
 
         def inbox_cards
-          inbox_list.cards.sample(3)
+          inbox_list.cards
         end
       end
     end

--- a/spec/lita/commands/trello/get_cards_spec.rb
+++ b/spec/lita/commands/trello/get_cards_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe Lita::Commands::Trello::GetRandomCards do
+RSpec.describe Lita::Commands::Trello::GetCards do
   let(:config) do
     double(developer_public_key: 'XXX', member_token: 'YYY')
   end
@@ -9,11 +9,11 @@ RSpec.describe Lita::Commands::Trello::GetRandomCards do
 
   let(:cards) do
     [
-      double(id: "XXX1", name: "Card 1", desc: "Description 1", pos: 1),
-      double(id: "XXX2", name: "Card 2", desc: "Description 2", pos: 2),
-      double(id: "XXX3", name: "Card 3", desc: "Description 3", pos: 3),
-      double(id: "XXX4", name: "Card 4", desc: "Description 4", pos: 4),
-      double(id: "XXX5", name: "Card 5", desc: "Description 5", pos: 5)
+      double(id: "XXX1", name: "Card 1", desc: "Description 1", short_url: "https://trello.com/a"),
+      double(id: "XXX2", name: "Card 2", desc: "Description 2", short_url: "https://trello.com/b"),
+      double(id: "XXX3", name: "Card 3", desc: "Description 3", short_url: "https://trello.com/c"),
+      double(id: "XXX4", name: "Card 4", desc: "Description 4", short_url: "https://trello.com/d"),
+      double(id: "XXX5", name: "Card 5", desc: "Description 5", short_url: "https://trello.com/e")
     ]
   end
 
@@ -43,9 +43,7 @@ RSpec.describe Lita::Commands::Trello::GetRandomCards do
         mock_boards
       end
 
-      it "raises error" do
-        expect { exec_cmd }.to raise_error("Platanus board not found")
-      end
+      it { expect { exec_cmd }.to raise_error("Platanus board not found") }
     end
 
     context "without INBOX list" do
@@ -54,21 +52,14 @@ RSpec.describe Lita::Commands::Trello::GetRandomCards do
         mock_boards
       end
 
-      it "raises error" do
-        expect { exec_cmd }.to raise_error("INBOX list not found")
-      end
+      it { expect { exec_cmd }.to raise_error("INBOX list not found") }
     end
 
     context "with valid data" do
       before { mock_boards }
 
-      it "returns 3 random cards" do
-        expect(exec_cmd.count).to eq(3)
-      end
-
-      it "returns random cards" do
-        expect(cards).to include(*exec_cmd)
-      end
+      it { expect(exec_cmd.count).to eq(5) }
+      it { expect(cards).to include(*exec_cmd) }
     end
   end
 end


### PR DESCRIPTION
Cambié para que se devolvieran todas las tarjetas de INBOX.
@felbalart Vi que en el modelo pusiste: `:id, :name, :owner, :created_at` pero esta es la información que viene en las cards:

```
#<Trello::Card:0x007fda9b9d0170 @attributes={:id=>"583ec9863af1a298a246e5ba", :short_id=>350, :name=>"Con two factor authentication habilitado en github, falla la publicación de una gema.", :desc=>"", :due=>nil, :closed=>false, :url=>"https://trello.com/c/i45jLKmF/350-con-two-factor-authentication-habilitado-en-github-falla-la-publicacion-de-una-gema", :short_url=>"https://trello.com/c/i45jLKmF", :board_id=>"54a1bb2fedb25f0551b42171", :member_ids=>[], :list_id=>"54a1bb668d81f6b921a5dbdc", :pos=>0.5000009536743164, :last_activity_date=>2016-12-01 13:13:16 UTC, :labels=>[], :card_labels=>[], :cover_image_id=>nil, :badges=>{"votes"=>0, "viewingMemberVoted"=>false, "subscribed"=>false, "fogbugz"=>"", "checkItems"=>0, "checkItemsChecked"=>0, "comments"=>2, "attachments"=>0, "description"=>false, "due"=>nil, "dueComplete"=>false}, :card_members=>nil, :source_card_id=>nil, :source_card_properties=>nil},
```

No viene ni la fecha de creación ni el owner. De todos me parece que esa información no es importante. No hace falta que sepamos de quienes son las tarjetas que votamos y tampoco es relevante la fecha de creación siendo que podemos usar la cantidad de votos o la fecha de los votos para determinar la edad de una tarjeta.

Si incluí la `short_url` en la respuesta para tener un link directo a las tarjetas por si uno quiere más información para votar.